### PR TITLE
Add native image plugin, for #480

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,8 +158,8 @@ Unless otherwise stated, files in Spork are under the [MIT license](LICENSE).
 
 ## Experimental: compile as a native image
 
-Spork can be compiled a native executable file using [GraalVM](https://www.graalvm.org/).
-To do so, you need to first install GraalVM's JDK for Java 17 (Spork does not support Java 21 yet, see [#409](https://github.com/ASSERT-KTH/spork/issues/479)).
+Spork can be compiled to a native executable file using [GraalVM](https://www.graalvm.org/).
+To do so, you need to first install GraalVM's JDK for Java 17 (Spork does not support Java 21 yet, see [#479](https://github.com/ASSERT-KTH/spork/issues/479)).
 Running `mvn package -P native` will then generate a native image in `target/spork`.
 
 **Note:** the native image is known to behave differently to the `.jar` file, producing different conflict resolution results. Help to debug this would be welcome.

--- a/README.md
+++ b/README.md
@@ -155,3 +155,12 @@ Unless otherwise stated, files in Spork are under the [MIT license](LICENSE).
   file is composed of code from
   [gumtree-spoon-ast-diff](https://github.com/spoon/gumtree-spoon-ast-diff) and
   is therefore individually licensed under Apache License 2.0.
+
+## Experimental: compile as a native image
+
+Spork can be compiled a native executable file using [GraalVM](https://www.graalvm.org/).
+To do so, you need to first install GraalVM's JDK for Java 17 (Spork does not support Java 21 yet, see [#409](https://github.com/ASSERT-KTH/spork/issues/479)).
+Running `mvn package -P native` will then generate a native image in `target/spork`.
+
+**Note:** the native image is known to behave differently to the `.jar` file, producing different conflict resolution results. Help to debug this would be welcome.
+

--- a/pom.xml
+++ b/pom.xml
@@ -13,6 +13,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <kotlin.version>1.7.10</kotlin.version>
+        <native.maven.plugin.version>0.9.12</native.maven.plugin.version>
     </properties>
 
     <repositories>
@@ -277,4 +278,47 @@
         </plugins>
     </build>
 
+    <profiles>
+        <profile>
+            <id>native</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.graalvm.buildtools</groupId>
+                        <artifactId>native-maven-plugin</artifactId>
+                        <version>${native.maven.plugin.version}</version>
+                        <extensions>true</extensions>
+                        <executions>
+                            <execution>
+                                <id>build-native</id>
+                                <goals>
+                                    <goal>build</goal>
+                                </goals>
+                                <phase>package</phase>
+                            </execution>
+                            <!-- <execution>
+                                <id>test-native</id>
+                                <goals>
+                                    <goal>test</goal>
+                                </goals>
+                                <phase>test</phase>
+                            </execution> -->
+                        </executions>
+                        <configuration>
+                            <fallback>false</fallback>
+                            <buildArgs>
+                                <arg>-H:DashboardDump=fortune -H:+DashboardAll</arg>
+                            </buildArgs>
+                            <agent>
+                                <enabled>true</enabled>
+                                <options>
+                                    <option>experimental-class-loader-support</option>
+                                </options>
+                            </agent>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -296,13 +296,6 @@
                                 </goals>
                                 <phase>package</phase>
                             </execution>
-                            <!-- <execution>
-                                <id>test-native</id>
-                                <goals>
-                                    <goal>test</goal>
-                                </goals>
-                                <phase>test</phase>
-                            </execution> -->
                         </executions>
                         <configuration>
                             <fallback>false</fallback>


### PR DESCRIPTION
Attempt to follow https://www.graalvm.org/22.2/reference-manual/native-image/guides/use-native-image-maven-plugin/.

To invoke it you need to use GraalVM 17 (22 is not supported, see #479) and run `mvn package -P native`.
This generates a native image in `target/spork`, which remains to be tested…