### PR TITLE
graalvm: Run native tests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -46,7 +46,7 @@
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter</artifactId>
-            <version>5.9.0</version>
+            <version>5.10.2</version>
             <scope>test</scope>
         </dependency>
 
@@ -296,6 +296,13 @@
                                 </goals>
                                 <phase>package</phase>
                             </execution>
+                            <execution>
+                                <id>test-native</id>
+                                <goals>
+                                    <goal>test</goal>
+                                </goals>
+                                <phase>test</phase>
+                            </execution>
                         </executions>
                         <configuration>
                             <fallback>false</fallback>
@@ -304,9 +311,6 @@
                             </buildArgs>
                             <agent>
                                 <enabled>true</enabled>
-                                <options>
-                                    <option>experimental-class-loader-support</option>
-                                </options>
                             </agent>
                         </configuration>
                     </plugin>


### PR DESCRIPTION
This makes it possible to run tests via native image with `mvn -P native test`.

What I find interesting is that it does show some failing tests, but not the same ones as the inputs where @slarse noticed that the outputs were different in https://github.com/ASSERT-KTH/spork/pull/481#issuecomment-1913688408.

For instance, on my machine the `method_visibility_left_empty` test passes in `mvn -P native test`, but the output of the native binary is different from the expected one.
I have strictly no idea why!