### PR TITLE
[misc] Hide output of succeeding tests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -46,9 +46,16 @@
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter</artifactId>
-            <version>5.9.0</version>
+            <version>5.10.2</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.junit.platform</groupId>
+            <artifactId>junit-platform-launcher</artifactId>
+            <version>1.10.2</version>
+            <scope>test</scope>
+        </dependency>
+
 
         <!-- logging -->
         <dependency>

--- a/src/test/java/se/kth/spork/TestOutputHandler.java
+++ b/src/test/java/se/kth/spork/TestOutputHandler.java
@@ -1,0 +1,35 @@
+package se.kth.spork;
+
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+import org.junit.platform.engine.TestExecutionResult;
+import org.junit.platform.launcher.TestExecutionListener;
+import org.junit.platform.launcher.TestIdentifier;
+
+public class TestOutputHandler implements TestExecutionListener {
+    private final PrintStream stdout = System.out;
+    private final PrintStream stderr = System.err;
+
+    private final ByteArrayOutputStream capturedStdout = new ByteArrayOutputStream();
+    private final ByteArrayOutputStream capturedStderr = new ByteArrayOutputStream();
+
+    @Override
+    public void executionStarted(TestIdentifier testIdentifier) {
+        System.setOut(new PrintStream(capturedStdout));
+        System.setErr(new PrintStream(capturedStderr));
+    }
+
+    @Override
+    public void executionFinished(TestIdentifier testIdentifier, TestExecutionResult testExecutionResult) {
+        System.setOut(stdout);
+        System.setErr(stderr);
+        if (testExecutionResult.getStatus().equals(TestExecutionResult.Status.FAILED)) {
+            System.out.printf("### OUTPUT FROM %s (%s) ###", testIdentifier.getLegacyReportingName(), testIdentifier.getDisplayName());
+            System.out.println(capturedStdout.toString());
+            System.out.println(capturedStderr.toString());
+        }
+
+        capturedStdout.reset();
+        capturedStderr.reset();
+    }
+}

--- a/src/test/resources/META-INF/services/org.junit.platform.launcher.TestExecutionListener
+++ b/src/test/resources/META-INF/services/org.junit.platform.launcher.TestExecutionListener
@@ -1,0 +1,1 @@
+se.kth.spork.TestOutputHandler


### PR DESCRIPTION
Adds a test execution listener that only shows the output of a test if it fails.